### PR TITLE
fix: prefix squid image with urn

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: "Dockerfile"
 runs:
   using: "docker"
-  image: "squ1d123/dockerfilelint:1.4.0"
+  image: "docker://squ1d123/dockerfilelint:1.4.0"
   args:
     - ${{ inputs.dockerfile }}
 branding:


### PR DESCRIPTION
#### Description

Updated the squid image reference with docker urn 

#### Motivation and Context

Without the urn the action is unable to find the image

#### How Has This Been Tested?

Tested locally and in the action tests

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

No changes to test or documentation required.
