### PR TITLE
fix: remove auto readme version update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,30 +23,6 @@ jobs:
         id: bumper
         uses: tomerfi/version-bumper-action@1.1.3
 
-      - name: Update README major version
-        id: version_count
-        run: echo "::set-output name=count::$(fgrep -c rusty-actions/dockerfile-linter@v${{ steps.bumper.outputs.major_part }} ) README.md"
-
-      - name: Update README usage example
-        if: steps.version_count.outputs.count == 0
-        run: |
-          sed -i 's|uses\: rusty-actions/rusty-actions/dockerfile-linter@.*|uses\: rusty-actions/rusty-actions/dockerfile-linter@v${{ steps.bumper.outputs.major_part }}|g' README.md
-
-      - name: Configure git
-        if: steps.version_count.outputs.count == 0
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Push modifications
-        if: steps.version_count.outputs.count == 0
-        run: |
-          if [[ ! $(git diff --quiet) ]]; then
-            git add README.md
-            git commit -m "docs: update README usage section with v${{ steps.bumper.outputs.major_part }} [skip ci]"
-            git push
-          fi
-
       - name: Create tag
         uses: rickstaa/action-create-tag@v1
         with:


### PR DESCRIPTION
#### Description

Remove the auto update of the version in the readme on major version change. This is not required as if a major version change then the documentation should be fully updated to match the breaking changes.

#### Motivation and Context

Simplifies the workflows and removes error prone changes. Fixes current issue.
Closes #

#### How Has This Been Tested?

NA

#### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
